### PR TITLE
feat(LeafGlucoseSimulation): Add initial stored glucose parameter

### DIFF
--- a/src/glucose.ts
+++ b/src/glucose.ts
@@ -3,7 +3,6 @@ import { PlantGlucoseSimulation } from './plantGlucoseSimulation';
 type SVG = typeof SVG.Doc;
 
 export abstract class Glucose {
-  protected buffer = 25;
   protected image: SVG.Image;
   protected simulation: PlantGlucoseSimulation;
   constructor(simulation: PlantGlucoseSimulation) {

--- a/src/glucoseToStorage.ts
+++ b/src/glucoseToStorage.ts
@@ -21,8 +21,8 @@ export abstract class GlucoseToStorage extends Glucose {
   protected moveY(): number {
     return (
       this.simulation.getStorage().getY() +
-      Math.floor(this.simulation.getTotalGlucoseStored() / 2 / 5) * 75 -
-      this.buffer
+      Math.floor(this.simulation.getTotalGlucoseStored() / 2 / 5) * 75 +
+      this.getBuffer()
     );
   }
 

--- a/src/glucoseToStorage.ts
+++ b/src/glucoseToStorage.ts
@@ -2,29 +2,12 @@ import { Glucose } from './glucose';
 
 export abstract class GlucoseToStorage extends Glucose {
   animate(): any {
+    const coordinates = this.simulation.getNextGlucoseStoredCoordinates();
     return this.image
       .animate({
         delay: this.simulation.animationDelay,
         duration: this.simulation.animationDuration,
       })
-      .move(this.moveX(), this.moveY());
+      .move(coordinates[0], coordinates[1]);
   }
-
-  protected moveX(): number {
-    return (
-      this.simulation.getStorage().getX() +
-      ((this.simulation.getTotalGlucoseStored() / 2) % 5) * 75 +
-      this.getBuffer()
-    );
-  }
-
-  protected moveY(): number {
-    return (
-      this.simulation.getStorage().getY() +
-      Math.floor(this.simulation.getTotalGlucoseStored() / 2 / 5) * 75 +
-      this.getBuffer()
-    );
-  }
-
-  protected abstract getBuffer(): number;
 }

--- a/src/glucoseToStorage.ts
+++ b/src/glucoseToStorage.ts
@@ -8,6 +8,7 @@ export abstract class GlucoseToStorage extends Glucose {
         delay: this.simulation.animationDelay,
         duration: this.simulation.animationDuration,
       })
-      .move(coordinates[0], coordinates[1]);
+      .move(coordinates[0], coordinates[1])
+      .afterAll(() => this.image.rotate(Math.random() * 360));
   }
 }

--- a/src/glucoseToStorage.ts
+++ b/src/glucoseToStorage.ts
@@ -10,6 +10,21 @@ export abstract class GlucoseToStorage extends Glucose {
       .move(this.moveX(), this.moveY());
   }
 
-  protected abstract moveX(): number;
-  protected abstract moveY(): number;
+  protected moveX(): number {
+    return (
+      this.simulation.getStorage().getX() +
+      ((this.simulation.getTotalGlucoseStored() / 2) % 5) * 75 +
+      this.getBuffer()
+    );
+  }
+
+  protected moveY(): number {
+    return (
+      this.simulation.getStorage().getY() +
+      Math.floor(this.simulation.getTotalGlucoseStored() / 2 / 5) * 75 -
+      this.buffer
+    );
+  }
+
+  protected abstract getBuffer(): number;
 }

--- a/src/glucoseToStorage1.ts
+++ b/src/glucoseToStorage1.ts
@@ -1,10 +1,6 @@
 import { GlucoseToStorage } from './glucoseToStorage';
 
 export class GlucoseToStorage1 extends GlucoseToStorage {
-  protected getBuffer(): number {
-    return this.buffer * -1;
-  }
-
   getStartX(): number {
     return 400;
   }

--- a/src/glucoseToStorage1.ts
+++ b/src/glucoseToStorage1.ts
@@ -4,7 +4,7 @@ export class GlucoseToStorage1 extends GlucoseToStorage {
   protected moveX(): number {
     return (
       this.simulation.getStorage().getX() +
-      ((this.simulation.glucosesInStorage.length / 2) % 5) * 75 -
+      ((this.simulation.getTotalGlucoseStored() / 2) % 5) * 75 -
       this.buffer
     );
   }
@@ -12,7 +12,7 @@ export class GlucoseToStorage1 extends GlucoseToStorage {
   protected moveY(): number {
     return (
       this.simulation.getStorage().getY() +
-      Math.floor(this.simulation.glucosesInStorage.length / 2 / 5) * 75 -
+      Math.floor(this.simulation.getTotalGlucoseStored() / 2 / 5) * 75 -
       this.buffer
     );
   }

--- a/src/glucoseToStorage1.ts
+++ b/src/glucoseToStorage1.ts
@@ -1,20 +1,8 @@
 import { GlucoseToStorage } from './glucoseToStorage';
 
 export class GlucoseToStorage1 extends GlucoseToStorage {
-  protected moveX(): number {
-    return (
-      this.simulation.getStorage().getX() +
-      ((this.simulation.getTotalGlucoseStored() / 2) % 5) * 75 -
-      this.buffer
-    );
-  }
-
-  protected moveY(): number {
-    return (
-      this.simulation.getStorage().getY() +
-      Math.floor(this.simulation.getTotalGlucoseStored() / 2 / 5) * 75 -
-      this.buffer
-    );
+  protected getBuffer(): number {
+    return this.buffer * -1;
   }
 
   getStartX(): number {

--- a/src/glucoseToStorage2.ts
+++ b/src/glucoseToStorage2.ts
@@ -4,7 +4,7 @@ export class GlucoseToStorage2 extends GlucoseToStorage {
   protected moveX(): number {
     return (
       this.simulation.getStorage().getX() +
-      ((this.simulation.glucosesInStorage.length / 2) % 5) * 75 +
+      ((this.simulation.getTotalGlucoseStored() / 2) % 5) * 75 +
       this.buffer
     );
   }
@@ -12,7 +12,7 @@ export class GlucoseToStorage2 extends GlucoseToStorage {
   protected moveY(): number {
     return (
       this.simulation.getStorage().getY() +
-      Math.floor(this.simulation.glucosesInStorage.length / 2 / 5) * 75 +
+      Math.floor(this.simulation.getTotalGlucoseStored() / 2 / 5) * 75 +
       this.buffer
     );
   }

--- a/src/glucoseToStorage2.ts
+++ b/src/glucoseToStorage2.ts
@@ -1,10 +1,6 @@
 import { GlucoseToStorage } from './glucoseToStorage';
 
 export class GlucoseToStorage2 extends GlucoseToStorage {
-  protected getBuffer(): number {
-    return this.buffer;
-  }
-
   getStartX(): number {
     return 475;
   }

--- a/src/glucoseToStorage2.ts
+++ b/src/glucoseToStorage2.ts
@@ -1,20 +1,8 @@
 import { GlucoseToStorage } from './glucoseToStorage';
 
 export class GlucoseToStorage2 extends GlucoseToStorage {
-  protected moveX(): number {
-    return (
-      this.simulation.getStorage().getX() +
-      ((this.simulation.getTotalGlucoseStored() / 2) % 5) * 75 +
-      this.buffer
-    );
-  }
-
-  protected moveY(): number {
-    return (
-      this.simulation.getStorage().getY() +
-      Math.floor(this.simulation.getTotalGlucoseStored() / 2 / 5) * 75 +
-      this.buffer
-    );
+  protected getBuffer(): number {
+    return this.buffer;
   }
 
   getStartX(): number {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -110,15 +110,6 @@ export class Graph {
           visible: this.settings.showLineGlucoseMade,
         },
         {
-          name: 'Total Glucose Used',
-          color: '#f17d00',
-          lineWidth: 3,
-          data: [],
-          dashStyle: 'shortDash',
-          showInLegend: this.settings.showLineGlucoseUsed,
-          visible: this.settings.showLineGlucoseUsed,
-        },
-        {
           name: 'Glucose in Storage',
           color: '#459db6',
           lineWidth: 3,
@@ -126,6 +117,15 @@ export class Graph {
           dashStyle: 'dot',
           showInLegend: this.settings.showLineGlucoseStored,
           visible: this.settings.showLineGlucoseStored,
+        },
+        {
+          name: 'Total Glucose Used',
+          color: '#f17d00',
+          lineWidth: 3,
+          data: [],
+          dashStyle: 'shortDash',
+          showInLegend: this.settings.showLineGlucoseUsed,
+          visible: this.settings.showLineGlucoseUsed,
         },
         {
           name: 'Light Level',
@@ -208,8 +208,8 @@ export class Graph {
    */
   private updateGraph(): void {
     this.setSeriesData(0, this.simulation.currentTrial.glucoseCreated);
-    this.setSeriesData(1, this.simulation.currentTrial.glucoseUsed);
-    this.setSeriesData(2, this.simulation.currentTrial.glucoseStored);
+    this.setSeriesData(1, this.simulation.currentTrial.glucoseStored);
+    this.setSeriesData(2, this.simulation.currentTrial.glucoseUsed);
     this.setSeriesData(3, this.simulation.currentTrial.lightLevel);
     this.setSeriesData(4, this.simulation.currentTrial.waterLevel);
 

--- a/src/highchartsTrialConverter.ts
+++ b/src/highchartsTrialConverter.ts
@@ -14,20 +14,20 @@ export function convertToHighchartsTrial(trial: Trial): any {
         trial.glucoseCreated
       ),
       convertToHighchartsSeries(
-        trial.id + '-glucoseUsed',
-        'Total Glucose Used',
-        '#f17d00',
-        'shortDash',
-        'circle',
-        trial.glucoseUsed
-      ),
-      convertToHighchartsSeries(
         trial.id + '-glucoseStored',
         'Total Glucose Stored',
         '#459db6',
         'dot',
         'circle',
         trial.glucoseStored
+      ),
+      convertToHighchartsSeries(
+        trial.id + '-glucoseUsed',
+        'Total Glucose Used',
+        '#f17d00',
+        'shortDash',
+        'circle',
+        trial.glucoseUsed
       ),
     ],
   };

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -60,7 +60,7 @@ export class PlantGlucoseSimulation {
   private glucoseToMitochondrion2: GlucoseToMitochondrion2;
   private glucoseToStorage1: GlucoseToStorage1;
   private glucoseToStorage2: GlucoseToStorage2;
-  glucosesInStorage: GlucoseToStorage[] = [];
+  glucosesInStorage: SVG.Image[] = [];
   instructions: any[] = [];
   isControlEnabled: boolean = true;
   isLightOn: boolean = true;
@@ -122,7 +122,7 @@ export class PlantGlucoseSimulation {
       let glucose: GlucoseToStorage;
       glucose = new GlucoseToStorage1(this);
       glucose.animate();
-      this.glucosesInStorage.push(glucose);
+      this.glucosesInStorage.push(glucose.getImage());
     }
     this.animationDuration = realAnimationDuration;
   }
@@ -515,13 +515,15 @@ export class PlantGlucoseSimulation {
       this.currentAnimation = this.draw.set();
       let glucose1InStorage =
         this.glucosesInStorage[this.getTotalGlucoseStored() - 1];
-      let glucose2InStorage: GlucoseToStorage = null;
+      let glucose2InStorage: SVG.Image = null;
 
       if (this.getTotalGlucoseStored() >= 2 && !requiresAssist) {
         glucose2InStorage =
           this.glucosesInStorage[this.getTotalGlucoseStored() - 2];
 
         if (glucose2InStorage != null) {
+          glucose1InStorage.rotate(0);
+          glucose2InStorage.rotate(0);
           if (
             (this.settings.isDroughtTolerant && this.numPhotonsThisCycle > 2) ||
             (this.settings.isShadeTolerant && this.numWaterThisCycle > 0)
@@ -701,6 +703,7 @@ export class PlantGlucoseSimulation {
     eventBus.emit('dayChanged', 1);
 
     this.currentDayNumber = 0;
+    this.blobCircleRadius = 10;
     this.totalGlucoseCreated = this.settings.initialGlucoseStored;
     this.totalGlucoseUsed = 0;
     this.glucosesInStorage = [];
@@ -809,6 +812,7 @@ export class PlantGlucoseSimulation {
     const centerX = this.storage.getX() + 150;
     const centerY = this.storage.getY() + 130;
     const nextGlucoseNum = this.getTotalGlucoseStored() + 1;
+    this.blobCircleRadius -= 1 / nextGlucoseNum;
     const groupNum = this.getGlucoseGroupNumber(nextGlucoseNum);
     const positionInGroup = this.getGlucosePositionInGroup(nextGlucoseNum);
     const isSquareGroup = this.isSquareGroup(groupNum);
@@ -829,7 +833,9 @@ export class PlantGlucoseSimulation {
    *                   stored would be 1, second would be 2, etc)
    */
   private getGlucoseGroupNumber(glucoseNum: number): number {
-    return Math.ceil(glucoseNum / 4);
+    let group = Math.ceil(glucoseNum / 4);
+    if (glucoseNum >= 41) group -= 10;
+    return group;
   }
 
   private getGlucosePositionInGroup(glucoseNum: number): number {

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -116,14 +116,13 @@ export class PlantGlucoseSimulation {
   }
 
   private addInitialGlucosesToStorage() {
-    const realAnimationDuration = this.animationDuration;
-    this.animationDuration = 500;
     for (let i = 0; i < this.settings.initialGlucoseStored; i++) {
       const glucose = new GlucoseToStorage1(this);
-      glucose.animate();
+      const coordinates = this.getNextGlucoseStoredCoordinates();
+      glucose.getImage().move(coordinates[0], coordinates[1]);
+      glucose.getImage().rotate(Math.random() * 360);
       this.glucosesInStorage.push(glucose.getImage());
     }
-    this.animationDuration = realAnimationDuration;
   }
 
   loadInstructions(instructions: any[]): void {

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -79,7 +79,7 @@ export class PlantGlucoseSimulation {
   private storage: Storage;
   private totalGlucoseCreated = 0;
   private totalGlucoseUsed = 0;
-  private totalGlucoseStored = 0;
+  private totalGlucoseStored = 2;
   private trials: any[] = []; // an array of trial data objects including the current trial
   private wiseAPI: WISEAPI;
 
@@ -95,8 +95,10 @@ export class PlantGlucoseSimulation {
     this.draw = SVG(elementId);
     this.numDays = this.settings.numDays;
     this.chloroplast = new Chloroplast(this);
+    this.totalGlucoseStored = this.settings.initialGlucoseStored;
     this.mitochondrion = new Mitochondrion(this);
     this.storage = new Storage(this);
+    this.addInitialGlucosesToStorage();
     this.feedback = new Feedback(this.draw, this.settings.feedbackPolicy);
     this.wiseAPI = new WISEAPI(this);
     this.startNewTrial();
@@ -110,6 +112,22 @@ export class PlantGlucoseSimulation {
     eventBus.on('animationDeathSequenceEnded').subscribe(() => {
       this.handleAnimationDeathSequenceEnded();
     });
+  }
+
+  private addInitialGlucosesToStorage() {
+    const realAnimationDuration = this.animationDuration;
+    this.animationDuration = 1;
+    for (let i = 0; i < this.settings.initialGlucoseStored; i++) {
+      let glucose: GlucoseToStorage;
+      if (i % 2 === 0) {
+        glucose = new GlucoseToStorage1(this);
+      } else {
+        glucose = new GlucoseToStorage2(this);
+      }
+      this.glucosesInStorage.push(glucose);
+      glucose.animate();
+    }
+    this.animationDuration = realAnimationDuration;
   }
 
   loadInstructions(instructions: any[]): void {
@@ -184,7 +202,8 @@ export class PlantGlucoseSimulation {
     this.currentTrial = new Trial(
       `Trial (${this.trials.length + 1})`,
       this.numPhotonsThisCycle,
-      this.numWaterThisCycle
+      this.numWaterThisCycle,
+      this.settings.initialGlucoseStored
     );
     this.trials.push(this.currentTrial);
     this.notifyStudentDataChanged();
@@ -200,7 +219,10 @@ export class PlantGlucoseSimulation {
     if (glucoseUsed) {
       this.updateGlucoseUsed();
     }
-    this.totalGlucoseStored = this.totalGlucoseCreated - this.totalGlucoseUsed;
+    this.totalGlucoseStored =
+      this.totalGlucoseCreated -
+      this.totalGlucoseUsed +
+      this.settings.initialGlucoseStored;
     this.currentTrial.addDayData(
       this.currentDayNumber,
       this.totalGlucoseCreated,
@@ -243,6 +265,7 @@ export class PlantGlucoseSimulation {
       if (
         this.glucosesInStorage.length === 0 &&
         (this.glucoseCreatedIncrement === 0 || this.numWaterThisCycle === 0)
+        // this.totalGlucoseStored === 0
       ) {
         // there is no energy coming in or stored. The plant dies now.
         this.currentAnimation = this.draw
@@ -651,7 +674,9 @@ export class PlantGlucoseSimulation {
     this.currentDayNumber = 0;
     this.totalGlucoseCreated = 0;
     this.totalGlucoseUsed = 0;
-    this.totalGlucoseStored = 0;
+    this.totalGlucoseStored = this.settings.initialGlucoseStored;
+    this.glucosesInStorage = [];
+    this.addInitialGlucosesToStorage();
     this.feedback.hideFeedback();
     if (!this.settings.enableInputControls) {
       this.setInputValues(this.playSequence[0]);

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -119,8 +119,7 @@ export class PlantGlucoseSimulation {
     const realAnimationDuration = this.animationDuration;
     this.animationDuration = 500;
     for (let i = 0; i < this.settings.initialGlucoseStored; i++) {
-      let glucose: GlucoseToStorage;
-      glucose = new GlucoseToStorage1(this);
+      const glucose = new GlucoseToStorage1(this);
       glucose.animate();
       this.glucosesInStorage.push(glucose.getImage());
     }

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -82,6 +82,8 @@ export class PlantGlucoseSimulation {
   private trials: any[] = []; // an array of trial data objects including the current trial
   private wiseAPI: WISEAPI;
 
+  private blobCircleRadius = 10;
+
   /**
    * Instantiates variables with initial values for objects
    * within the simulation. Controlling the simulation (play/pause/reset)
@@ -119,8 +121,8 @@ export class PlantGlucoseSimulation {
     for (let i = 0; i < this.settings.initialGlucoseStored; i++) {
       let glucose: GlucoseToStorage;
       glucose = new GlucoseToStorage1(this);
-      this.glucosesInStorage.push(glucose);
       glucose.animate();
+      this.glucosesInStorage.push(glucose);
     }
     this.animationDuration = realAnimationDuration;
   }
@@ -486,18 +488,17 @@ export class PlantGlucoseSimulation {
       this.glucoseToStorage1 = null;
       if (this.glucoseCreatedIncrement !== 4) {
         animationCallback();
+      } else {
+        this.glucoseToStorage2.animate().afterAll(() => {
+          this.glucosesInStorage.push(this.glucoseToStorage2.clone());
+          this.glucoseToStorage2.remove();
+          this.glucoseToStorage2 = null;
+          animationCallback();
+        });
+        this.currentAnimation.add(this.glucoseToStorage2.getImage());
       }
     });
     this.currentAnimation.add(this.glucoseToStorage1.getImage());
-    if (this.glucoseCreatedIncrement === 4) {
-      this.glucoseToStorage2.animate().afterAll(() => {
-        this.glucosesInStorage.push(this.glucoseToStorage2.clone());
-        this.glucoseToStorage2.remove();
-        this.glucoseToStorage2 = null;
-        animationCallback();
-      });
-      this.currentAnimation.add(this.glucoseToStorage2.getImage());
-    }
   }
 
   /**
@@ -802,5 +803,111 @@ export class PlantGlucoseSimulation {
 
   getTotalGlucoseStored(): number {
     return this.glucosesInStorage.length;
+  }
+
+  getNextGlucoseStoredCoordinates(): [number, number] {
+    const centerX = this.storage.getX() + 150;
+    const centerY = this.storage.getY() + 130;
+    const nextGlucoseNum = this.getTotalGlucoseStored() + 1;
+    const groupNum = this.getGlucoseGroupNumber(nextGlucoseNum);
+    const positionInGroup = this.getGlucosePositionInGroup(nextGlucoseNum);
+    const isSquareGroup = this.isSquareGroup(groupNum);
+
+    return this.getAdjustedCoordinates(
+      centerX,
+      centerY,
+      groupNum,
+      positionInGroup,
+      isSquareGroup
+    );
+  }
+
+  /**
+   * Determines which group a glucose molecule is in where a group is a group
+   * of four glucoses that will be displayed in the same ring.
+   * @param glucoseNum number representing the glucose (the first glucose
+   *                   stored would be 1, second would be 2, etc)
+   */
+  private getGlucoseGroupNumber(glucoseNum: number): number {
+    return Math.ceil(glucoseNum / 4);
+  }
+
+  private getGlucosePositionInGroup(glucoseNum: number): number {
+    for (let i = 0; i < 4; i++) {
+      // The 4th member of the group is always a multiple of 4
+      if ((glucoseNum + i) % 4 === 0) {
+        return 4 - i;
+      }
+    }
+  }
+
+  /**
+   * Determines whether a glucose is in a group to be displayed as a square
+   * or a group to be displayed as a diamond.
+   * @param groupNum a group of four glucoses (the first four are group 1, the
+   *                 second four are group 2, etc)
+   */
+  private isSquareGroup(groupNum: number): boolean {
+    return groupNum % 2 !== 0;
+  }
+
+  private getAdjustedCoordinates(
+    centerX: number,
+    centerY: number,
+    groupNum: number,
+    positionInGroup: number,
+    isSquareGroup: boolean
+  ): [number, number] {
+    const groupRingRadius = this.getGroupRingRadius(groupNum, isSquareGroup);
+    const xModifier = this.getCoordinateModifier(
+      positionInGroup,
+      isSquareGroup,
+      true
+    );
+    const yModifier = this.getCoordinateModifier(
+      positionInGroup,
+      isSquareGroup,
+      false
+    );
+    const adjustedX = centerX + groupRingRadius * xModifier;
+    const adjustedY = centerY + groupRingRadius * yModifier;
+    return [adjustedX, adjustedY];
+  }
+
+  private getGroupRingRadius(groupNum: number, isSquareGroup: boolean): number {
+    return (
+      (this.blobCircleRadius * groupNum * Math.sqrt(2)) /
+      (isSquareGroup ? 2 : 1)
+    );
+  }
+
+  private getCoordinateModifier(
+    positionInGroup: number,
+    isSquareGroup: boolean,
+    isXCoord: boolean
+  ): number {
+    if (isXCoord) {
+      switch (positionInGroup) {
+        case 1:
+          return isSquareGroup ? 1 : 0;
+        case 2:
+          return 1;
+        case 3:
+          return isSquareGroup ? -1 : 0;
+        case 4:
+          return -1;
+      }
+    } else {
+      switch (positionInGroup) {
+        case 1:
+          return 1;
+        case 2:
+          return isSquareGroup ? -1 : 0;
+        case 3:
+          return -1;
+        case 4:
+          return isSquareGroup ? 1 : 0;
+      }
+    }
   }
 }

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -186,12 +186,24 @@ export class PlantGlucoseSimulation {
   private resumeSimulation(): void {
     this.simulationState = SimulationState.Running;
     eventBus.emit('simulationStateChanged', SimulationState.Running);
-    this.currentAnimation.play();
+    this.currentAnimation.members.forEach((glucose: any) => {
+      if (glucose instanceof GlucoseToStorage1) {
+        glucose.getImage().play();
+      } else {
+        glucose.play();
+      }
+    });
   }
 
   private pauseSimulation(): void {
     if (this.isAnimationPlaying()) {
-      this.currentAnimation.pause();
+      this.currentAnimation.members.forEach((glucose: any) => {
+        if (glucose instanceof GlucoseToStorage1) {
+          glucose.getImage().pause();
+        } else {
+          glucose.pause();
+        }
+      });
     }
     this.simulationState = SimulationState.Paused;
     eventBus.emit('simulationStateChanged', SimulationState.Paused);

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -186,27 +186,38 @@ export class PlantGlucoseSimulation {
   private resumeSimulation(): void {
     this.simulationState = SimulationState.Running;
     eventBus.emit('simulationStateChanged', SimulationState.Running);
-    this.currentAnimation.members.forEach((glucose: any) => {
-      if (glucose instanceof GlucoseToStorage1) {
-        glucose.getImage().play();
-      } else {
-        glucose.play();
-      }
-    });
+    this.playOrPauseAnimation(false);
   }
 
   private pauseSimulation(): void {
     if (this.isAnimationPlaying()) {
-      this.currentAnimation.members.forEach((glucose: any) => {
-        if (glucose instanceof GlucoseToStorage1) {
-          glucose.getImage().pause();
-        } else {
-          glucose.pause();
-        }
-      });
+      this.playOrPauseAnimation(true);
     }
     this.simulationState = SimulationState.Paused;
     eventBus.emit('simulationStateChanged', SimulationState.Paused);
+  }
+
+  private playOrPauseAnimation(isPausing: boolean): void {
+    if (this.currentAnimation.members) {
+      this.playOrPauseImages(isPausing);
+    } else {
+      this.playOrPause(this.currentAnimation, isPausing);
+    }
+  }
+
+  private playOrPauseImages(isPausing: boolean): void {
+    this.currentAnimation.members.forEach((animationObject: any) => {
+      if (animationObject instanceof GlucoseToStorage1) {
+        const glucoseImg = animationObject.getImage();
+        this.playOrPause(glucoseImg, isPausing);
+      } else {
+        this.playOrPause(animationObject, isPausing);
+      }
+    });
+  }
+
+  private playOrPause(playOrPauseObject: any, isPausing: boolean): void {
+    isPausing ? playOrPauseObject.pause() : playOrPauseObject.play();
   }
 
   private handleAnimationDeathSequenceEnded(): void {

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -77,9 +77,8 @@ export class PlantGlucoseSimulation {
   private playSequence: any[] = [];
   private simulationState: SimulationState = SimulationState.Stopped;
   private storage: Storage;
-  private totalGlucoseCreated = 0;
+  private totalGlucoseCreated: number;
   private totalGlucoseUsed = 0;
-  private totalGlucoseStored = 2;
   private trials: any[] = []; // an array of trial data objects including the current trial
   private wiseAPI: WISEAPI;
 
@@ -95,10 +94,10 @@ export class PlantGlucoseSimulation {
     this.draw = SVG(elementId);
     this.numDays = this.settings.numDays;
     this.chloroplast = new Chloroplast(this);
-    this.totalGlucoseStored = this.settings.initialGlucoseStored;
     this.mitochondrion = new Mitochondrion(this);
     this.storage = new Storage(this);
     this.addInitialGlucosesToStorage();
+    this.totalGlucoseCreated = this.settings.initialGlucoseStored;
     this.feedback = new Feedback(this.draw, this.settings.feedbackPolicy);
     this.wiseAPI = new WISEAPI(this);
     this.startNewTrial();
@@ -116,14 +115,10 @@ export class PlantGlucoseSimulation {
 
   private addInitialGlucosesToStorage() {
     const realAnimationDuration = this.animationDuration;
-    this.animationDuration = 1;
+    this.animationDuration = 500;
     for (let i = 0; i < this.settings.initialGlucoseStored; i++) {
       let glucose: GlucoseToStorage;
-      if (i % 2 === 0) {
-        glucose = new GlucoseToStorage1(this);
-      } else {
-        glucose = new GlucoseToStorage2(this);
-      }
+      glucose = new GlucoseToStorage1(this);
       this.glucosesInStorage.push(glucose);
       glucose.animate();
     }
@@ -165,15 +160,19 @@ export class PlantGlucoseSimulation {
 
   private handlePlayPauseButtonClicked(): void {
     if (this.isControlEnabled) {
-      if (this.simulationState === SimulationState.Stopped) {
-        this.addEvent('startButtonClicked');
-        this.startSimulation();
-      } else if (this.simulationState === SimulationState.Paused) {
-        this.addEvent('resumeButtonClicked');
-        this.resumeSimulation();
-      } else if (this.simulationState === SimulationState.Running) {
-        this.addEvent('pauseButtonClicked');
-        this.pauseSimulation();
+      switch (this.simulationState) {
+        case SimulationState.Stopped:
+          this.addEvent('startButtonClicked');
+          this.startSimulation();
+          break;
+        case SimulationState.Paused:
+          this.addEvent('resumeButtonClicked');
+          this.resumeSimulation();
+          break;
+        case SimulationState.Running:
+          this.addEvent('pauseButtonClicked');
+          this.pauseSimulation();
+          break;
       }
     }
   }
@@ -188,6 +187,14 @@ export class PlantGlucoseSimulation {
     this.simulationState = SimulationState.Running;
     eventBus.emit('simulationStateChanged', SimulationState.Running);
     this.currentAnimation.play();
+  }
+
+  private pauseSimulation(): void {
+    if (this.isAnimationPlaying()) {
+      this.currentAnimation.pause();
+    }
+    this.simulationState = SimulationState.Paused;
+    eventBus.emit('simulationStateChanged', SimulationState.Paused);
   }
 
   private handleAnimationDeathSequenceEnded(): void {
@@ -219,15 +226,11 @@ export class PlantGlucoseSimulation {
     if (glucoseUsed) {
       this.updateGlucoseUsed();
     }
-    this.totalGlucoseStored =
-      this.totalGlucoseCreated -
-      this.totalGlucoseUsed +
-      this.settings.initialGlucoseStored;
     this.currentTrial.addDayData(
       this.currentDayNumber,
       this.totalGlucoseCreated,
       this.totalGlucoseUsed,
-      this.totalGlucoseStored,
+      this.getTotalGlucoseStored(),
       this.numPhotonsThisCycle,
       this.numWaterThisCycle
     );
@@ -263,9 +266,8 @@ export class PlantGlucoseSimulation {
       }
       eventBus.emit('animationCyclePhase1Started');
       if (
-        this.glucosesInStorage.length === 0 &&
+        this.getTotalGlucoseStored() === 0 &&
         (this.glucoseCreatedIncrement === 0 || this.numWaterThisCycle === 0)
-        // this.totalGlucoseStored === 0
       ) {
         // there is no energy coming in or stored. The plant dies now.
         this.currentAnimation = this.draw
@@ -281,7 +283,7 @@ export class PlantGlucoseSimulation {
         this.movePhotonsToPlantAndChloroplast(
           this.animationCallback.bind(this)
         );
-      } else if (this.glucosesInStorage.length > 0) {
+      } else if (this.getTotalGlucoseStored() > 0) {
         this.moveGlucoseFromStorageToMitochondrion(
           this.animationCallback.bind(this)
         );
@@ -459,7 +461,9 @@ export class PlantGlucoseSimulation {
       this.glucosesInStorage.push(this.glucoseToStorage1.clone());
       this.glucoseToStorage1.remove();
       this.glucoseToStorage1 = null;
-      animationCallback();
+      if (this.glucoseCreatedIncrement !== 4) {
+        animationCallback();
+      }
     });
     this.currentAnimation.add(this.glucoseToStorage1.getImage());
     if (this.glucoseCreatedIncrement === 4) {
@@ -467,6 +471,7 @@ export class PlantGlucoseSimulation {
         this.glucosesInStorage.push(this.glucoseToStorage2.clone());
         this.glucoseToStorage2.remove();
         this.glucoseToStorage2 = null;
+        animationCallback();
       });
       this.currentAnimation.add(this.glucoseToStorage2.getImage());
     }
@@ -480,17 +485,17 @@ export class PlantGlucoseSimulation {
     animationCallback: () => {},
     requiresAssist: boolean = false
   ): void {
-    if (this.glucosesInStorage.length === 0) {
+    if (this.getTotalGlucoseStored() === 0) {
       animationCallback();
     } else {
       this.currentAnimation = this.draw.set();
       let glucose1InStorage =
-        this.glucosesInStorage[this.glucosesInStorage.length - 1];
+        this.glucosesInStorage[this.getTotalGlucoseStored() - 1];
       let glucose2InStorage: GlucoseToStorage = null;
 
-      if (this.glucosesInStorage.length >= 2 && !requiresAssist) {
+      if (this.getTotalGlucoseStored() >= 2 && !requiresAssist) {
         glucose2InStorage =
-          this.glucosesInStorage[this.glucosesInStorage.length - 2];
+          this.glucosesInStorage[this.getTotalGlucoseStored() - 2];
 
         if (glucose2InStorage != null) {
           if (
@@ -537,7 +542,7 @@ export class PlantGlucoseSimulation {
         })
         .afterAll(() => {
           // remove the last glucose from storage
-          this.glucosesInStorage.splice(this.glucosesInStorage.length - 1, 1);
+          this.glucosesInStorage.splice(this.getTotalGlucoseStored() - 1, 1);
           glucose1InStorage.remove();
           glucose1InStorage = null;
           if (
@@ -546,7 +551,7 @@ export class PlantGlucoseSimulation {
               this.numWaterThisCycle === 0) ||
               (this.numPhotonsThisCycle < 3 && !this.settings.isShadeTolerant))
           ) {
-            this.glucosesInStorage.splice(this.glucosesInStorage.length - 1, 1);
+            this.glucosesInStorage.splice(this.getTotalGlucoseStored() - 1, 1);
             glucose2InStorage.remove();
             glucose2InStorage = null;
           }
@@ -672,9 +677,8 @@ export class PlantGlucoseSimulation {
     eventBus.emit('dayChanged', 1);
 
     this.currentDayNumber = 0;
-    this.totalGlucoseCreated = 0;
+    this.totalGlucoseCreated = this.settings.initialGlucoseStored;
     this.totalGlucoseUsed = 0;
-    this.totalGlucoseStored = this.settings.initialGlucoseStored;
     this.glucosesInStorage = [];
     this.addInitialGlucosesToStorage();
     this.feedback.hideFeedback();
@@ -715,14 +719,6 @@ export class PlantGlucoseSimulation {
       timestamp: new Date().getTime(),
     };
     this.currentTrial.events.push(event);
-  }
-
-  private pauseSimulation(): void {
-    if (this.isAnimationPlaying()) {
-      this.currentAnimation.pause();
-    }
-    this.simulationState = SimulationState.Paused;
-    eventBus.emit('simulationStateChanged', SimulationState.Paused);
   }
 
   /**
@@ -779,5 +775,9 @@ export class PlantGlucoseSimulation {
 
   getSettings(): Settings {
     return this.settings;
+  }
+
+  getTotalGlucoseStored(): number {
+    return this.glucosesInStorage.length;
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,7 +39,7 @@ export class Settings {
     this.showWater = parameters['showWater'] ?? false;
     this.enableInputControls = parameters['enableInputControls'] ?? true;
     this.initialGlucoseStored = parameters['initialGlucoseStored'] ?? 2;
-    if (this.initialGlucoseStored < 0) {
+    if (this.initialGlucoseStored < 0 || this.initialGlucoseStored > 20) {
       this.initialGlucoseStored = 2;
     }
     this.isDroughtTolerant = parameters['isDroughtTolerant'] ?? false;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 export class Settings {
   enableInputControls = true;
   feedbackPolicy: string = null; // contain the identifier of the feedback to use
+  initialGlucoseStored: number = 2;
   isDroughtTolerant = false;
   isShadeTolerant = false;
   lightLevelLabels = ['OFF', 'ON'];
@@ -37,6 +38,10 @@ export class Settings {
     this.showSpeedControls = parameters['showSpeedControls'] ?? false;
     this.showWater = parameters['showWater'] ?? false;
     this.enableInputControls = parameters['enableInputControls'] ?? true;
+    this.initialGlucoseStored = parameters['initialGlucoseStored'] ?? 2;
+    if (this.initialGlucoseStored < 0) {
+      this.initialGlucoseStored = 2;
+    }
     this.isDroughtTolerant = parameters['isDroughtTolerant'] ?? false;
     this.isShadeTolerant = parameters['isShadeTolerant'] ?? false;
     this.plantImgSrc = parameters['plantImgSrc'] ?? null;

--- a/src/trial.ts
+++ b/src/trial.ts
@@ -1,3 +1,5 @@
+import { Settings } from './settings';
+
 export class Trial {
   id: number;
   name: string;
@@ -8,11 +10,17 @@ export class Trial {
   waterLevel: number[][];
   events: any[] = [];
 
-  constructor(name: string, numPhotons: number, numWater: number) {
+  constructor(
+    name: string,
+    numPhotons: number,
+    numWater: number,
+    initialGlucoseStored: number
+  ) {
     this.id = new Date().getTime();
     this.name = name;
     this.lightLevel = [[0, numPhotons]];
     this.waterLevel = [[0, numWater]];
+    this.glucoseStored = [[0, initialGlucoseStored]];
   }
 
   addDayData(

--- a/src/trial.ts
+++ b/src/trial.ts
@@ -1,11 +1,9 @@
-import { Settings } from './settings';
-
 export class Trial {
   id: number;
   name: string;
-  glucoseCreated: number[][] = [[0, 0]];
+  glucoseCreated: number[][];
   glucoseUsed: number[][] = [[0, 0]];
-  glucoseStored: number[][] = [[0, 0]];
+  glucoseStored: number[][];
   lightLevel: number[][];
   waterLevel: number[][];
   events: any[] = [];
@@ -20,6 +18,7 @@ export class Trial {
     this.name = name;
     this.lightLevel = [[0, numPhotons]];
     this.waterLevel = [[0, numWater]];
+    this.glucoseCreated = [[0, initialGlucoseStored]];
     this.glucoseStored = [[0, initialGlucoseStored]];
   }
 


### PR DESCRIPTION
## Changes
- Added a URL parameter for the amount of glucose that the plant starts with. (Must be a value from 0-20)
- Re-ordered graph labels to match the typical order of the lines. (Glucose created > glucose stored > glucose used)
- Removed duplicate process of tracking total glucose stored.
  - Previously tracked in this.glucosesInStorage array and in this.totalGlucoseStored. Removed this.totalGlucoseStored and added this.getTotalGlucoseStored() which just checks how many glucoses are stored in this.glucosesInStorage.

## Test
- Make sure that the model works properly:
  - Can toggle light on and off which starts/stops glucose production in the chloroplast.
  - Can pause/play the simulation.
  - Can reset the simulation.
- Make sure that the default number of glucoses initially stored is 2.
- Make sure that trying to give an initial glucose stored value less than 0 or greater than 20 defaults to 2.

Closes #37 