### PR TITLE
feat(LeafGlucoseSimulation): Display stored glucose in an expanding circular blob

### DIFF
--- a/src/glucose.ts
+++ b/src/glucose.ts
@@ -3,7 +3,6 @@ import { PlantGlucoseSimulation } from './plantGlucoseSimulation';
 type SVG = typeof SVG.Doc;
 
 export abstract class Glucose {
-  protected buffer = 25;
   protected image: SVG.Image;
   protected simulation: PlantGlucoseSimulation;
   constructor(simulation: PlantGlucoseSimulation) {

--- a/src/glucoseToStorage.ts
+++ b/src/glucoseToStorage.ts
@@ -2,29 +2,12 @@ import { Glucose } from './glucose';
 
 export abstract class GlucoseToStorage extends Glucose {
   animate(): any {
+    const coordinates = this.simulation.getNextGlucoseStoredCoordinates();
     return this.image
       .animate({
         delay: this.simulation.animationDelay,
         duration: this.simulation.animationDuration,
       })
-      .move(this.moveX(), this.moveY());
+      .move(coordinates[0], coordinates[1]);
   }
-
-  protected moveX(): number {
-    return (
-      this.simulation.getStorage().getX() +
-      ((this.simulation.getTotalGlucoseStored() / 2) % 5) * 75 +
-      this.getBuffer()
-    );
-  }
-
-  protected moveY(): number {
-    return (
-      this.simulation.getStorage().getY() +
-      Math.floor(this.simulation.getTotalGlucoseStored() / 2 / 5) * 75 +
-      this.getBuffer()
-    );
-  }
-
-  protected abstract getBuffer(): number;
 }

--- a/src/glucoseToStorage.ts
+++ b/src/glucoseToStorage.ts
@@ -8,6 +8,7 @@ export abstract class GlucoseToStorage extends Glucose {
         delay: this.simulation.animationDelay,
         duration: this.simulation.animationDuration,
       })
-      .move(coordinates[0], coordinates[1]);
+      .move(coordinates[0], coordinates[1])
+      .afterAll(() => this.image.rotate(Math.random() * 360));
   }
 }

--- a/src/glucoseToStorage1.ts
+++ b/src/glucoseToStorage1.ts
@@ -1,10 +1,6 @@
 import { GlucoseToStorage } from './glucoseToStorage';
 
 export class GlucoseToStorage1 extends GlucoseToStorage {
-  protected getBuffer(): number {
-    return this.buffer * -1;
-  }
-
   getStartX(): number {
     return 400;
   }

--- a/src/glucoseToStorage2.ts
+++ b/src/glucoseToStorage2.ts
@@ -1,10 +1,6 @@
 import { GlucoseToStorage } from './glucoseToStorage';
 
 export class GlucoseToStorage2 extends GlucoseToStorage {
-  protected getBuffer(): number {
-    return this.buffer;
-  }
-
   getStartX(): number {
     return 475;
   }

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -60,7 +60,7 @@ export class PlantGlucoseSimulation {
   private glucoseToMitochondrion2: GlucoseToMitochondrion2;
   private glucoseToStorage1: GlucoseToStorage1;
   private glucoseToStorage2: GlucoseToStorage2;
-  glucosesInStorage: GlucoseToStorage[] = [];
+  glucosesInStorage: SVG.Image[] = [];
   instructions: any[] = [];
   isControlEnabled: boolean = true;
   isLightOn: boolean = true;
@@ -122,7 +122,7 @@ export class PlantGlucoseSimulation {
       let glucose: GlucoseToStorage;
       glucose = new GlucoseToStorage1(this);
       glucose.animate();
-      this.glucosesInStorage.push(glucose);
+      this.glucosesInStorage.push(glucose.getImage());
     }
     this.animationDuration = realAnimationDuration;
   }
@@ -515,13 +515,15 @@ export class PlantGlucoseSimulation {
       this.currentAnimation = this.draw.set();
       let glucose1InStorage =
         this.glucosesInStorage[this.getTotalGlucoseStored() - 1];
-      let glucose2InStorage: GlucoseToStorage = null;
+      let glucose2InStorage: SVG.Image = null;
 
       if (this.getTotalGlucoseStored() >= 2 && !requiresAssist) {
         glucose2InStorage =
           this.glucosesInStorage[this.getTotalGlucoseStored() - 2];
 
         if (glucose2InStorage != null) {
+          glucose1InStorage.rotate(0);
+          glucose2InStorage.rotate(0);
           if (
             (this.settings.isDroughtTolerant && this.numPhotonsThisCycle > 2) ||
             (this.settings.isShadeTolerant && this.numWaterThisCycle > 0)
@@ -701,6 +703,7 @@ export class PlantGlucoseSimulation {
     eventBus.emit('dayChanged', 1);
 
     this.currentDayNumber = 0;
+    this.blobCircleRadius = 10;
     this.totalGlucoseCreated = this.settings.initialGlucoseStored;
     this.totalGlucoseUsed = 0;
     this.glucosesInStorage = [];
@@ -809,6 +812,7 @@ export class PlantGlucoseSimulation {
     const centerX = this.storage.getX() + 150;
     const centerY = this.storage.getY() + 130;
     const nextGlucoseNum = this.getTotalGlucoseStored() + 1;
+    this.blobCircleRadius -= 1 / nextGlucoseNum;
     const groupNum = this.getGlucoseGroupNumber(nextGlucoseNum);
     const positionInGroup = this.getGlucosePositionInGroup(nextGlucoseNum);
     const isSquareGroup = this.isSquareGroup(groupNum);
@@ -829,7 +833,9 @@ export class PlantGlucoseSimulation {
    *                   stored would be 1, second would be 2, etc)
    */
   private getGlucoseGroupNumber(glucoseNum: number): number {
-    return Math.ceil(glucoseNum / 4);
+    let group = Math.ceil(glucoseNum / 4);
+    if (glucoseNum >= 41) group -= 10;
+    return group;
   }
 
   private getGlucosePositionInGroup(glucoseNum: number): number {

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -116,14 +116,13 @@ export class PlantGlucoseSimulation {
   }
 
   private addInitialGlucosesToStorage() {
-    const realAnimationDuration = this.animationDuration;
-    this.animationDuration = 500;
     for (let i = 0; i < this.settings.initialGlucoseStored; i++) {
       const glucose = new GlucoseToStorage1(this);
-      glucose.animate();
+      const coordinates = this.getNextGlucoseStoredCoordinates();
+      glucose.getImage().move(coordinates[0], coordinates[1]);
+      glucose.getImage().rotate(Math.random() * 360);
       this.glucosesInStorage.push(glucose.getImage());
     }
-    this.animationDuration = realAnimationDuration;
   }
 
   loadInstructions(instructions: any[]): void {

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -119,8 +119,7 @@ export class PlantGlucoseSimulation {
     const realAnimationDuration = this.animationDuration;
     this.animationDuration = 500;
     for (let i = 0; i < this.settings.initialGlucoseStored; i++) {
-      let glucose: GlucoseToStorage;
-      glucose = new GlucoseToStorage1(this);
+      const glucose = new GlucoseToStorage1(this);
       glucose.animate();
       this.glucosesInStorage.push(glucose.getImage());
     }

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -82,6 +82,8 @@ export class PlantGlucoseSimulation {
   private trials: any[] = []; // an array of trial data objects including the current trial
   private wiseAPI: WISEAPI;
 
+  private blobCircleRadius = 10;
+
   /**
    * Instantiates variables with initial values for objects
    * within the simulation. Controlling the simulation (play/pause/reset)
@@ -119,8 +121,8 @@ export class PlantGlucoseSimulation {
     for (let i = 0; i < this.settings.initialGlucoseStored; i++) {
       let glucose: GlucoseToStorage;
       glucose = new GlucoseToStorage1(this);
-      this.glucosesInStorage.push(glucose);
       glucose.animate();
+      this.glucosesInStorage.push(glucose);
     }
     this.animationDuration = realAnimationDuration;
   }
@@ -486,18 +488,17 @@ export class PlantGlucoseSimulation {
       this.glucoseToStorage1 = null;
       if (this.glucoseCreatedIncrement !== 4) {
         animationCallback();
+      } else {
+        this.glucoseToStorage2.animate().afterAll(() => {
+          this.glucosesInStorage.push(this.glucoseToStorage2.clone());
+          this.glucoseToStorage2.remove();
+          this.glucoseToStorage2 = null;
+          animationCallback();
+        });
+        this.currentAnimation.add(this.glucoseToStorage2.getImage());
       }
     });
     this.currentAnimation.add(this.glucoseToStorage1.getImage());
-    if (this.glucoseCreatedIncrement === 4) {
-      this.glucoseToStorage2.animate().afterAll(() => {
-        this.glucosesInStorage.push(this.glucoseToStorage2.clone());
-        this.glucoseToStorage2.remove();
-        this.glucoseToStorage2 = null;
-        animationCallback();
-      });
-      this.currentAnimation.add(this.glucoseToStorage2.getImage());
-    }
   }
 
   /**
@@ -802,5 +803,111 @@ export class PlantGlucoseSimulation {
 
   getTotalGlucoseStored(): number {
     return this.glucosesInStorage.length;
+  }
+
+  getNextGlucoseStoredCoordinates(): [number, number] {
+    const centerX = this.storage.getX() + 150;
+    const centerY = this.storage.getY() + 130;
+    const nextGlucoseNum = this.getTotalGlucoseStored() + 1;
+    const groupNum = this.getGlucoseGroupNumber(nextGlucoseNum);
+    const positionInGroup = this.getGlucosePositionInGroup(nextGlucoseNum);
+    const isSquareGroup = this.isSquareGroup(groupNum);
+
+    return this.getAdjustedCoordinates(
+      centerX,
+      centerY,
+      groupNum,
+      positionInGroup,
+      isSquareGroup
+    );
+  }
+
+  /**
+   * Determines which group a glucose molecule is in where a group is a group
+   * of four glucoses that will be displayed in the same ring.
+   * @param glucoseNum number representing the glucose (the first glucose
+   *                   stored would be 1, second would be 2, etc)
+   */
+  private getGlucoseGroupNumber(glucoseNum: number): number {
+    return Math.ceil(glucoseNum / 4);
+  }
+
+  private getGlucosePositionInGroup(glucoseNum: number): number {
+    for (let i = 0; i < 4; i++) {
+      // The 4th member of the group is always a multiple of 4
+      if ((glucoseNum + i) % 4 === 0) {
+        return 4 - i;
+      }
+    }
+  }
+
+  /**
+   * Determines whether a glucose is in a group to be displayed as a square
+   * or a group to be displayed as a diamond.
+   * @param groupNum a group of four glucoses (the first four are group 1, the
+   *                 second four are group 2, etc)
+   */
+  private isSquareGroup(groupNum: number): boolean {
+    return groupNum % 2 !== 0;
+  }
+
+  private getAdjustedCoordinates(
+    centerX: number,
+    centerY: number,
+    groupNum: number,
+    positionInGroup: number,
+    isSquareGroup: boolean
+  ): [number, number] {
+    const groupRingRadius = this.getGroupRingRadius(groupNum, isSquareGroup);
+    const xModifier = this.getCoordinateModifier(
+      positionInGroup,
+      isSquareGroup,
+      true
+    );
+    const yModifier = this.getCoordinateModifier(
+      positionInGroup,
+      isSquareGroup,
+      false
+    );
+    const adjustedX = centerX + groupRingRadius * xModifier;
+    const adjustedY = centerY + groupRingRadius * yModifier;
+    return [adjustedX, adjustedY];
+  }
+
+  private getGroupRingRadius(groupNum: number, isSquareGroup: boolean): number {
+    return (
+      (this.blobCircleRadius * groupNum * Math.sqrt(2)) /
+      (isSquareGroup ? 2 : 1)
+    );
+  }
+
+  private getCoordinateModifier(
+    positionInGroup: number,
+    isSquareGroup: boolean,
+    isXCoord: boolean
+  ): number {
+    if (isXCoord) {
+      switch (positionInGroup) {
+        case 1:
+          return isSquareGroup ? 1 : 0;
+        case 2:
+          return 1;
+        case 3:
+          return isSquareGroup ? -1 : 0;
+        case 4:
+          return -1;
+      }
+    } else {
+      switch (positionInGroup) {
+        case 1:
+          return 1;
+        case 2:
+          return isSquareGroup ? -1 : 0;
+        case 3:
+          return -1;
+        case 4:
+          return isSquareGroup ? 1 : 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Changes
- Glucoses are stored in a blob that starts from the center of the vacuole and expands outward.
- Once the blob has expanded so much that the center starts looking weird, new glucoses start getting stored from the center and out again.
- When a glucose reaches the vacuole, a random rotation is applied to it so that neat rows don't end up forming. The rotation is removed before the glucose is moved to the mitochondria.

## Test
- Make sure that initial glucoses are displayed properly.
- Make sure that glucoses created during the simulation are displayed properly.
- Make sure that glucoses can move from storage to the mitochondria in the same way as before.

Closes #39 