### PR TITLE
feat(LeafGlucoseSimulation): Display different images for different glucose levels

### DIFF
--- a/src/plantAnimationCorner.ts
+++ b/src/plantAnimationCorner.ts
@@ -94,7 +94,7 @@ export class PlantAnimationCorner {
       .on('numWaterChanged')
       .subscribe((numWater: number) => this.updateWatering(numWater));
     eventBus
-      .on('simulationReset')
+      .on('glucoseReset')
       .subscribe(() => this.updateImg(this.simulation.getTotalGlucoseStored()));
     eventBus
       .on('endOfDay')

--- a/src/plantAnimationCorner.ts
+++ b/src/plantAnimationCorner.ts
@@ -153,23 +153,23 @@ export class PlantAnimationCorner {
 
   private setPlantImages(plantImages: string[]) {
     this.deadImg = this.draw.image(plantImages.at(0), 500, 500).attr({
-      y: 392,
+      y: 340,
       opacity: 0.4,
     });
     this.unhealthyImg = this.draw.image(plantImages.at(1), 500, 500).attr({
-      y: 392,
+      y: 340,
       opacity: 0.6,
     });
     this.moderateImg = this.draw.image(plantImages.at(2), 500, 500).attr({
-      y: 392,
+      y: 340,
       opacity: 0.8,
     });
     this.healthyImg = this.draw.image(plantImages.at(3), 500, 500).attr({
-      y: 392,
+      y: 340,
       opacity: 1,
     });
     this.veryHealthyImg = this.draw.image(plantImages.at(4), 500, 500).attr({
-      y: 392,
+      y: 340,
       opacity: 1,
     });
   }

--- a/src/plantAnimationCorner.ts
+++ b/src/plantAnimationCorner.ts
@@ -152,25 +152,17 @@ export class PlantAnimationCorner {
   }
 
   private setPlantImages(plantImages: string[]) {
-    this.deadImg = this.draw.image(plantImages.at(0), 500, 500).attr({
-      y: 340,
-      opacity: 0.4,
-    });
-    this.unhealthyImg = this.draw.image(plantImages.at(1), 500, 500).attr({
-      y: 340,
-      opacity: 0.6,
-    });
-    this.moderateImg = this.draw.image(plantImages.at(2), 500, 500).attr({
-      y: 340,
-      opacity: 0.8,
-    });
-    this.healthyImg = this.draw.image(plantImages.at(3), 500, 500).attr({
-      y: 340,
-      opacity: 1,
-    });
-    this.veryHealthyImg = this.draw.image(plantImages.at(4), 500, 500).attr({
-      y: 340,
-      opacity: 1,
+    this.deadImg = this.drawMainImage(plantImages.at(0), 340, 0.6);
+    this.unhealthyImg = this.drawMainImage(plantImages.at(1), 340, 0.7);
+    this.moderateImg = this.drawMainImage(plantImages.at(2), 340, 0.8);
+    this.healthyImg = this.drawMainImage(plantImages.at(3), 340, 0.9);
+    this.veryHealthyImg = this.drawMainImage(plantImages.at(4), 340, 1);
+  }
+
+  private drawMainImage(img: string, y: number, opacity: number): any {
+    return this.draw.image(img, 500, 500).attr({
+      y: y,
+      opacity: opacity,
     });
   }
 

--- a/src/plantAnimationCorner.ts
+++ b/src/plantAnimationCorner.ts
@@ -18,23 +18,17 @@ import { PlantPhotons } from './plantPhotons';
  * @author Geoffrey Kwan
  */
 export class PlantAnimationCorner {
-  GREEN_LEAF_INDEX: number = 0;
-  LIGHT_GREEN_LEAF_INDEX: number = 1;
-  YELLOW_LEAF_INDEX: number = 2;
-  DEAD_LEAF_INDEX: number = 3;
-
-  draw: SVG.Doc;
-  lightBulbOn: SVG.Image;
-  lightBulbOff: SVG.Image;
-  allLeaves: SVG.Image[];
-  leafYellow: SVG.Image;
-  leafLightGreen: SVG.Image;
-  leafGreen: SVG.Image;
-  leafDead: SVG.Image;
-  darknessOverlay: SVG.Rect;
-  wateringCan: SVG.Image;
-  customPlant: SVG;
-  showLightBulb: boolean = false;
+  private draw: SVG.Doc;
+  private lightBulbOn: SVG.Image;
+  private lightBulbOff: SVG.Image;
+  private deadImg: SVG.Image;
+  private unhealthyImg: SVG.Image;
+  private moderateImg: SVG.Image;
+  private healthyImg: SVG.Image;
+  private veryHealthyImg: SVG.Image;
+  private darknessOverlay: SVG.Rect;
+  private wateringCan: SVG.Image;
+  private showLightBulb: boolean = false;
 
   /**
    * Instantiates variables with initial values for objects
@@ -49,56 +43,13 @@ export class PlantAnimationCorner {
     this.draw.rect(500, 700).x(0).y(150).fill('white').stroke({ width: 2 });
 
     if (plantImgSrc) {
-      this.leafGreen = this.draw.image(plantImgSrc, 500, 500).attr({
-        y: 392,
-      });
-      this.leafYellow = this.draw.image(plantImgSrc, 500, 500).attr({
-        y: 392,
-        opacity: 0.6,
-      });
-      this.leafLightGreen = this.draw.image(plantImgSrc, 500, 500).attr({
-        y: 392,
-        opacity: 0.8,
-      });
-      this.leafDead = this.draw.image(plantImgSrc, 500, 500).attr({
-        y: 392,
-        opacity: 0.4,
-      });
+      this.setPlantImages(plantImgSrc);
     } else {
-      this.leafGreen = this.draw
-        .image('./images/leafGreen.png', 250, 250)
-        .attr({
-          x: 40,
-          y: 430,
-        });
-      this.leafYellow = this.draw
-        .image('./images/leafYellow.png', 250, 250)
-        .attr({
-          x: 40,
-          y: 530,
-        });
-      this.leafLightGreen = this.draw
-        .image('./images/leafLightGreen.png', 250, 250)
-        .attr({
-          x: 40,
-          y: 430,
-        });
-      this.draw.image('./images/pot.png', 250, 250).attr({ x: 125, y: 590 });
-      this.leafDead = this.draw.image('./images/leafDead.png', 250, 250).attr({
-        x: 80,
-        y: 580,
-      });
+      const plantImages = new Array(5).fill('./images/leafGreen.png');
+      this.setPlantImages(plantImages);
     }
 
-    // store all the leaf images in an array from liveliest -> dead
-    this.allLeaves = [
-      this.leafGreen,
-      this.leafLightGreen,
-      this.leafYellow,
-      this.leafDead,
-    ];
-
-    this.showLeaf(this.GREEN_LEAF_INDEX);
+    this.updateImg(this.simulation.getTotalGlucoseStored());
 
     this.darknessOverlay = this.draw.rect(500, 700).y(150).attr({
       'fill-opacity': 0.3,
@@ -138,28 +89,16 @@ export class PlantAnimationCorner {
     new PlantPhotons(this.simulation);
     eventBus
       .on('numPhotonsChanged')
-      .subscribe((numPhotons) => this.updateBackground(numPhotons));
+      .subscribe((numPhotons: number) => this.updateBackground(numPhotons));
     eventBus
       .on('numWaterChanged')
-      .subscribe((numWater) => this.updateWatering(numWater));
+      .subscribe((numWater: number) => this.updateWatering(numWater));
     eventBus
       .on('simulationReset')
-      .subscribe(() => this.showLeaf(this.GREEN_LEAF_INDEX));
-    eventBus.on('animationDeathSequenceStarted').subscribe(() => {
-      this.playPlantDeathSequence();
-    });
-  }
-
-  /**
-   * Change the leaf that is displayed based on the leaf index specified.
-   * 0 = green, 1 = light green, 2 = yellow, 3 = brown
-   * @param leafIndex which leaf should be shown
-   */
-  private showLeaf(leafIndex: number): void {
-    this.allLeaves.map((leaf) => {
-      leaf.hide();
-    });
-    this.allLeaves[leafIndex].show();
+      .subscribe(() => this.updateImg(this.simulation.getTotalGlucoseStored()));
+    eventBus
+      .on('endOfDay')
+      .subscribe(() => this.updateImg(this.simulation.getTotalGlucoseStored()));
   }
 
   /**
@@ -186,24 +125,6 @@ export class PlantAnimationCorner {
     }
   }
 
-  private playPlantDeathSequence(): any {
-    this.draw
-      .animate(3000 * this.simulation.animationSpeedRatio)
-      .during((pos, morph, eased, situation) => {
-        // show the death sequence animation leaf based on time
-        if (pos < 0.33) {
-          this.showLeaf(this.LIGHT_GREEN_LEAF_INDEX);
-        } else if (pos < 0.66) {
-          this.showLeaf(this.YELLOW_LEAF_INDEX);
-        } else {
-          this.showLeaf(this.DEAD_LEAF_INDEX);
-        }
-      })
-      .afterAll(() => {
-        eventBus.emit('animationDeathSequenceEnded');
-      });
-  }
-
   turnLightOff() {
     if (this.showLightBulb) {
       this.lightBulbOn.hide();
@@ -227,6 +148,56 @@ export class PlantAnimationCorner {
       this.wateringCan.show();
     } else {
       this.wateringCan.hide();
+    }
+  }
+
+  private setPlantImages(plantImages: string[]) {
+    this.deadImg = this.draw.image(plantImages.at(0), 500, 500).attr({
+      y: 392,
+      opacity: 0.4,
+    });
+    this.unhealthyImg = this.draw.image(plantImages.at(1), 500, 500).attr({
+      y: 392,
+      opacity: 0.6,
+    });
+    this.moderateImg = this.draw.image(plantImages.at(2), 500, 500).attr({
+      y: 392,
+      opacity: 0.8,
+    });
+    this.healthyImg = this.draw.image(plantImages.at(3), 500, 500).attr({
+      y: 392,
+      opacity: 1,
+    });
+    this.veryHealthyImg = this.draw.image(plantImages.at(4), 500, 500).attr({
+      y: 392,
+      opacity: 1,
+    });
+  }
+
+  private updateImg(totalGlucoseStored: number) {
+    this.hideAllPlantImg();
+    this.showRelevantPlantImg(totalGlucoseStored);
+  }
+
+  private hideAllPlantImg() {
+    this.deadImg.hide();
+    this.unhealthyImg.hide();
+    this.moderateImg.hide();
+    this.healthyImg.hide();
+    this.veryHealthyImg.hide();
+  }
+
+  private showRelevantPlantImg(totalGlucoseStored: number) {
+    if (totalGlucoseStored === 0) {
+      this.deadImg.show();
+    } else if (totalGlucoseStored <= 4) {
+      this.unhealthyImg.show();
+    } else if (totalGlucoseStored <= 10) {
+      this.moderateImg.show();
+    } else if (totalGlucoseStored <= 15) {
+      this.healthyImg.show();
+    } else {
+      this.veryHealthyImg.show();
     }
   }
 }

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -107,9 +107,6 @@ export class PlantGlucoseSimulation {
     eventBus
       .on('playPauseButtonClicked')
       .subscribe(() => this.handlePlayPauseButtonClicked());
-    eventBus.on('animationDeathSequenceEnded').subscribe(() => {
-      this.handleAnimationDeathSequenceEnded();
-    });
   }
 
   loadInstructions(instructions: any[]): void {
@@ -172,7 +169,7 @@ export class PlantGlucoseSimulation {
     this.currentAnimation.play();
   }
 
-  private handleAnimationDeathSequenceEnded(): void {
+  private animationDeathSequence(): void {
     this.addEvent('plantDied');
     eventBus.emit('statusChanged', 'died');
     this.updateCurrentTrial(false, false);
@@ -252,7 +249,7 @@ export class PlantGlucoseSimulation {
           })
           .afterAll(() => {
             this.disableControlButtons();
-            eventBus.emit('animationDeathSequenceStarted');
+            this.animationDeathSequence();
           });
       } else if (this.numPhotonsThisCycle > 0) {
         this.movePhotonsToPlantAndChloroplast(
@@ -574,7 +571,7 @@ export class PlantGlucoseSimulation {
           }
         } else {
           this.disableControlButtons();
-          eventBus.emit('animationDeathSequenceStarted');
+          this.animationDeathSequence();
         }
       });
     this.currentAnimation.add(this.mitochondrionBattery1.getImage());

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -263,6 +263,7 @@ export class PlantGlucoseSimulation {
           this.animationCallback.bind(this)
         );
       }
+      eventBus.emit('endOfDay');
       const nextDay = this.playSequence[this.currentDayNumber];
       if (nextDay) {
         this.setInputValues(nextDay);
@@ -754,5 +755,9 @@ export class PlantGlucoseSimulation {
 
   getSettings(): Settings {
     return this.settings;
+  }
+
+  getTotalGlucoseStored(): number {
+    return this.totalGlucoseStored;
   }
 }

--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -511,6 +511,7 @@ export class PlantGlucoseSimulation {
       this.currentAnimation = this.draw.set();
       let glucose1InStorage =
         this.glucosesInStorage[this.getTotalGlucoseStored() - 1];
+      glucose1InStorage.rotate(0);
       let glucose2InStorage: SVG.Image = null;
 
       if (this.getTotalGlucoseStored() >= 2 && !requiresAssist) {
@@ -518,7 +519,6 @@ export class PlantGlucoseSimulation {
           this.glucosesInStorage[this.getTotalGlucoseStored() - 2];
 
         if (glucose2InStorage != null) {
-          glucose1InStorage.rotate(0);
           glucose2InStorage.rotate(0);
           if (
             (this.settings.isDroughtTolerant && this.numPhotonsThisCycle > 2) ||
@@ -704,6 +704,7 @@ export class PlantGlucoseSimulation {
     this.totalGlucoseUsed = 0;
     this.glucosesInStorage = [];
     this.addInitialGlucosesToStorage();
+    eventBus.emit('glucoseReset');
     this.feedback.hideFeedback();
     if (!this.settings.enableInputControls) {
       this.setInputValues(this.playSequence[0]);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,7 +6,7 @@ export class Settings {
   lightLevelLabels = ['OFF', 'ON'];
   numDays = 20;
   numLightOptions = 2; // 2 = On/Off, 3 = Full/Half/Off, 5 = 100%/75%/50%/25%/0%
-  plantImgSrc: string = null;
+  plantImgSrc: string[] = [];
   showEnergyNeeds = false; // whether to show the battery and energy needs animation
   showGraph = true;
   showGraphBackground = false;
@@ -39,7 +39,7 @@ export class Settings {
     this.enableInputControls = parameters['enableInputControls'] ?? true;
     this.isDroughtTolerant = parameters['isDroughtTolerant'] ?? false;
     this.isShadeTolerant = parameters['isShadeTolerant'] ?? false;
-    this.plantImgSrc = parameters['plantImgSrc'] ?? null;
+    this.setPlantImgSrc(parameters['plantImgSrc']);
     this.showEnergyNeeds = parameters['showEnergyNeeds'] ?? false;
     this.lightLevelLabels = parameters['lightLevelLabels']
       ? parameters['lightLevelLabels'].split(',')
@@ -47,5 +47,23 @@ export class Settings {
     this.waterLevelLabels = parameters['waterLevelLabels']
       ? parameters['waterLevelLabels'].split(',')
       : ['NO', 'YES'];
+  }
+
+  private setPlantImgSrc(imgParam: string): void {
+    if (imgParam) {
+      const imgParamTokens = imgParam.split(',');
+      let counter = 0;
+      imgParamTokens.forEach((token) => {
+        counter++;
+        if (counter <= 5) this.plantImgSrc.push(token);
+      });
+      if (counter < 5) {
+        for (let i = counter; i < 5; i++) {
+          this.plantImgSrc.push(imgParamTokens.at(imgParamTokens.length - 1));
+        }
+      }
+    } else {
+      this.plantImgSrc = null;
+    }
   }
 }


### PR DESCRIPTION
## Changes
- Changed plantImgSrc parameter to take in a comma-separated list of images to represent the plant at 5 lifecycle stages: dead, unhealthy, moderate, healthy, and very healthy.
  - 0 Glucose --> Dead
  - 0 - 4 Glucose --> Unhealthy
  - 5 - 10 Glucose --> Moderate
  - 11 - 15 Glucose --> Healthy
  - 16+ --> Very Healthy

## Test
- The image changes at the end of the day.
- The model cycles through the images in the correct order as the amount of glucose increases and decreases.
- If between 1 and 4 images are given, the last image given is used for all the subsequent missing images.
- If more than 5 images are given, ignore any after the first 5.
- If no plantImgSrc is provided, use the deadLeaf > yellowLeaf > lightGreenLeaf > greenLeaf > greenLeaf as default.
- Make sure the rest of the simulation works the same as before.

Closes #36 