### PR TITLE
refactor(LeafGlucoseSimulation): Refactor simulation end feedback

### DIFF
--- a/src/displayStatusMessage.ts
+++ b/src/displayStatusMessage.ts
@@ -1,0 +1,46 @@
+import * as SVG from 'svg.js';
+type SVG = typeof SVG;
+import { eventBus } from './eventBus';
+
+export class DisplayStatusMessage {
+  private textBox: SVG;
+  private text: SVG;
+
+  constructor(
+    draw: SVG,
+    showOrganelles: boolean,
+    color: string,
+    text: string,
+    xOffsetText: number
+  ) {
+    const x = showOrganelles ? 250 : 0;
+    this.textBox = draw
+      .rect(500, 100)
+      .x(x)
+      .y(400)
+      .fill(color)
+      .stroke({ width: 2 })
+      .opacity(1)
+      .attr({ 'fill-opacity': 1 })
+      .hide();
+
+    this.text = draw
+      .text(text)
+      .x(x + xOffsetText)
+      .y(410)
+      .font({ size: 48 })
+      .hide();
+
+    eventBus.on('simulationReset').subscribe(() => this.hideMessage());
+  }
+
+  hideMessage() {
+    this.textBox.hide();
+    this.text.hide();
+  }
+
+  showMessage() {
+    this.textBox.show().front();
+    this.text.show().front();
+  }
+}

--- a/src/simulationEndFeedback.ts
+++ b/src/simulationEndFeedback.ts
@@ -1,6 +1,7 @@
 import * as SVG from 'svg.js';
 type SVG = typeof SVG;
 import { eventBus } from './eventBus';
+import { DisplayStatusMessage } from './displayStatusMessage';
 
 /**
  * SimulationEndFeedback --- Shows feedback that the simulation has ended,
@@ -10,124 +11,48 @@ import { eventBus } from './eventBus';
  * @author Jonathan Lim-Breitbart
  */
 export class SimulationEndFeedback {
-  plantAliveRect: SVG;
-  plantAliveText: SVG;
-  plantDiedRect: SVG;
-  plantDiedText: SVG;
-  simulationEndedRect: SVG;
-  simulationEndedText: SVG;
+  private plantAlive: DisplayStatusMessage;
+  private plantDied: DisplayStatusMessage;
+  private simulationEnded: DisplayStatusMessage;
 
   /**
    * Instantiates variables with initial values for the feedback
    * @param draw the SVG object where the view will be drawn on
    */
-  constructor(draw: SVG, showOragnelles: boolean) {
-    const x = showOragnelles ? 250 : 0;
-    this.simulationEndedRect = draw
-      .rect(500, 100)
-      .x(x)
-      .y(400)
-      .fill('lightblue')
-      .stroke({ width: 2 })
-      .opacity(1)
-      .attr({ 'fill-opacity': 1 })
-      .hide();
-
-    this.simulationEndedText = draw
-      .text('Simulation ended')
-      .x(x + 85)
-      .y(410)
-      .font({ size: 48 })
-      .hide();
-
-    this.plantAliveRect = draw
-      .rect(500, 100)
-      .x(x)
-      .y(400)
-      .fill('#33FF00')
-      .stroke({ width: 2 })
-      .opacity(1)
-      .attr({ 'fill-opacity': 1 })
-      .hide();
-
-    this.plantAliveText = draw
-      .text('The plant is alive')
-      .x(x + 72)
-      .y(410)
-      .font({ size: 48 })
-      .hide();
-
-    this.plantDiedRect = draw
-      .rect(500, 100)
-      .x(x)
-      .y(400)
-      .fill('#FF0000')
-      .stroke({ width: 2 })
-      .opacity(1)
-      .attr({ 'fill-opacity': 1 })
-      .hide();
-
-    this.plantDiedText = draw
-      .text('The plant has died')
-      .x(x + 50)
-      .y(410)
-      .font({ size: 48, fill: 'white' })
-      .hide();
-    eventBus.on('simulationReset').subscribe(() => this.hideAll());
+  constructor(draw: SVG, showOrganelles: boolean) {
+    this.simulationEnded = new DisplayStatusMessage(
+      draw,
+      showOrganelles,
+      'lightblue',
+      'Simulation ended',
+      85
+    );
+    this.plantAlive = new DisplayStatusMessage(
+      draw,
+      showOrganelles,
+      '#33FF00',
+      'The plant is alive',
+      72
+    );
+    this.plantDied = new DisplayStatusMessage(
+      draw,
+      showOrganelles,
+      '#FF0000',
+      'The plant has died',
+      50
+    );
     eventBus.on('statusChanged').subscribe((status: string) => {
       switch (status) {
         case 'died':
-          this.showPlantDied();
+          this.plantDied.showMessage();
           break;
         case 'survived':
-          this.showPlantAlive();
+          this.plantAlive.showMessage();
           break;
         case 'ended':
-          this.showSimulationEnded();
+          this.simulationEnded.showMessage();
           break;
       }
     });
-  }
-
-  /**
-   * Hide the 'Simulation Ended' and 'plant died' messages
-   */
-  private hideAll(): void {
-    this.plantDiedRect.hide();
-    this.plantDiedText.hide();
-    this.simulationEndedRect.hide();
-    this.simulationEndedText.hide();
-    this.plantAliveRect.hide();
-    this.plantAliveText.hide();
-  }
-
-  /**
-   * Shows plant died feedback and bring it to the front
-   */
-  showPlantDied() {
-    this.plantDiedRect.front();
-    this.plantDiedText.front();
-    this.plantDiedRect.show();
-    this.plantDiedText.show();
-  }
-
-  /**
-   * Shows simulation ended feedback and bring it to the front
-   */
-  showSimulationEnded() {
-    this.simulationEndedRect.front();
-    this.simulationEndedText.front();
-    this.simulationEndedRect.show();
-    this.simulationEndedText.show();
-  }
-
-  /**
-   * Shows plant alive feedback and bring it to the front
-   */
-  showPlantAlive() {
-    this.plantAliveRect.front();
-    this.plantAliveText.front();
-    this.plantAliveRect.show();
-    this.plantAliveText.show();
   }
 }


### PR DESCRIPTION
## Changes
- Moved duplicate code into new DisplayStatusMessage class and replaced the individual SVG objects in SimulationEndFeedback with instances of that class.

# Testing
- Make sure plant alive, plant died, and simulation end messages display properly.

Closes #45 