### PR TITLE
bug(Animation): Fixed slow glucose from storage to mitochondria

### DIFF
--- a/src/plantGlucoseSimulation.ts
+++ b/src/plantGlucoseSimulation.ts
@@ -505,6 +505,10 @@ export class PlantGlucoseSimulation {
     animationCallback: () => {},
     requiresAssist: boolean = false
   ): void {
+    const speedSettings = {
+      delay: this.animationDelay,
+      duration: this.animationDuration,
+    };
     if (this.getTotalGlucoseStored() === 0) {
       animationCallback();
     } else {
@@ -527,12 +531,12 @@ export class PlantGlucoseSimulation {
             this.mitochondrionBattery2 = new Battery2(this);
           } else {
             glucose2InStorage
-              .animate()
+              .animate(speedSettings)
               .move(
                 this.getMitochondrionBattery2StartPosition().x,
                 this.getMitochondrionBattery1StartPosition().y
               )
-              .animate()
+              .animate(speedSettings)
               .opacity(0)
               .afterAll(() => {
                 this.mitochondrionBattery2 = new Battery2(this);
@@ -548,14 +552,14 @@ export class PlantGlucoseSimulation {
         moveToY = this.getMitochondrionBattery2StartPosition().y;
       }
       glucose1InStorage
-        .animate()
+        .animate(speedSettings)
         .move(moveToX, moveToY)
         .during((pos, morph, eased, situation) => {
           if (!requiresAssist) {
             this.drainEnergy(100, 75, pos);
           }
         })
-        .animate()
+        .animate(speedSettings)
         .opacity(0)
         .during((pos, morph, eased, situation) => {
           if (!requiresAssist) {


### PR DESCRIPTION
## Changes
- Fixed bug where 2x and 4x speed settings were not applied to glucoses moving from the vacuole to the mitochondria

## Test
- Make sure glucoses moving from the vacuole to the mitochondria move at the correct speed given any of the three speed settings

Closes #44 